### PR TITLE
m/202501

### DIFF
--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -82,6 +82,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'profiles.context_processors.color_mode',
             ],
         },
     },

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("<int:pk>/", views.DetailView.as_view(), name="detail"),
     path("my/", views.DetailLoginUserView.as_view(), name="detail_login_user"),
     path("my/update/", views.UpdateLoginUserView.as_view(), name="update_login_user"),
+    path("my/color-mode/", ColorModeUpdateView.as_view(), name="color_mode_update"),
 ]

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,33 +1,42 @@
-from django.urls.base import reverse
-from django.views.generic import DetailView, UpdateView
+from django.urls import reverse
+from django.views.generic import DetailView, UpdateView, View
+from django.http import HttpResponseRedirect
 from . import forms
 from .models import Profile
 
-# Create your views here.
 class DetailView(DetailView):
-  template_name = "profiles/detail.html"
-  model = Profile
+    template_name = "profiles/detail.html"
+    model = Profile
 
 class DetailLoginUserView(DetailView):
-  template_name = "profiles/detail.html"
+    template_name = "profiles/detail.html"
 
-  """
-  URL上に `pk` パラメータを設けられないため
-  get_object() をオーバーライドして直接取得
-  """
-  def get_object(self):
-    return Profile.objects.get(user=self.request.user)
+    def get_object(self):
+        return Profile.objects.get(user=self.request.user)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["color_mode"] = self.request.COOKIES.get("color_mode", "light")  # デフォルトはライトモード
+        return context
 
 class UpdateLoginUserView(UpdateView):
-  form_class = forms.ProfileForm
-  template_name = "profiles/update_login_user.html"
+    form_class = forms.ProfileForm
+    template_name = "profiles/update_login_user.html"
 
-  """
-  URL上に `pk` パラメータを設けられないため
-  get_object() をオーバーライドして直接取得
-  """
-  def get_object(self):
-    return Profile.objects.get(user=self.request.user)
+    def get_object(self):
+        return Profile.objects.get(user=self.request.user)
 
-  def get_success_url(self):
-    return reverse('profiles:detail_login_user')
+    def get_success_url(self):
+        return reverse('profiles:detail_login_user')
+
+class ColorModeUpdateView(View):
+    """
+    カラーモードを変更するビュー
+    """
+    def post(self, request, *args, **kwargs):
+        current_mode = request.COOKIES.get("color_mode", "light")
+        new_mode = "dark" if current_mode == "light" else "light"
+
+        response = HttpResponseRedirect(request.META.get("HTTP_REFERER", reverse("profiles:detail_login_user")))
+        response.set_cookie("color_mode", new_mode, max_age=365*24*60*60)  # 1年間保持
+        return response

--- a/templates/profiles/detail.html
+++ b/templates/profiles/detail.html
@@ -5,6 +5,18 @@
 <div class="container">
     <h1 class="my-5">{{ profile.user.nickname }} さんのプロフィール</h1>
 
+    <!-- カラーモード切り替えボタン -->
+    <form action="{% url 'profiles:color_mode_update' %}" method="POST" class="mb-4">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-outline-secondary">
+            {% if color_mode == "dark" %}
+                🌞 ライトモードに切り替え
+            {% else %}
+                🌙 ダークモードに切り替え
+            {% endif %}
+        </button>
+    </form>
+
     <div>
         {{ profile.self_introduction | linebreaksbr }}
     </div>
@@ -14,6 +26,6 @@
             <a href="{% url 'profiles:update_login_user' %}" class="btn btn-lg btn-primary">編集する</a>
         </div>
     {% endif %}
-
 </div>
 {% endblock %}
+


### PR DESCRIPTION
解釈違ったらすみません。
今回の目標は
「画面上でダークモード・ライトモードの切り替え」
「カラーの切り替えはCookieの保存内容を参照する」

実装のイメージは
・プロフィール画面にカラーモードを切り替えるボタンを設置
　→切り替えのボタンのデザインは現在のカラーモードを参照して変更させる
　→デフォルトはライトモード
　　ボタンを押したらPOST リクエストが送られ、color_mode Cookie が更新される